### PR TITLE
Fix a wrong vignette index

### DIFF
--- a/vignettes/tidy-evaluation.Rmd
+++ b/vignettes/tidy-evaluation.Rmd
@@ -3,7 +3,7 @@ title: "Tidy evaluation"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Specifying fonts}
+  %\VignetteIndexEntry{Tidy evaluation}
   %\VignetteEngine{knitr::rmarkdown}
   \usepackage[utf8]{inputenc}
 ---


### PR DESCRIPTION
Congratulations for the release!

I found a weird index name for the vignette "Tidy evaluation". (Maybe is this a mistake when you copied from another existing vignette?)

> Vignettes: 	Specifying fonts
https://cran.r-project.org/web/packages/rlang/index.html