### PR TITLE
Fix capture of optimised promises

### DIFF
--- a/src/capture.c
+++ b/src/capture.c
@@ -26,6 +26,10 @@ SEXP attribute_hidden capture_arg(SEXP x, SEXP env) {
 }
 
 SEXP attribute_hidden capture_promise(SEXP x, int strict) {
+    // If promise was optimised away, return the literal
+    if (TYPEOF(x) != PROMSXP)
+        return capture_arg(x, R_EmptyEnv);
+
     SEXP env = R_NilValue;
     while (TYPEOF(x) == PROMSXP) {
         env = PRENV(x);

--- a/tests/testthat/test-quo-enquo.R
+++ b/tests/testthat/test-quo-enquo.R
@@ -16,3 +16,21 @@ test_that("explicit promise works only one level deep", {
 
   expect_identical(out$f, expected_f)
 })
+
+test_that("can capture optimised constants", {
+  arg <- function() {
+    quo("foobar")
+  }
+  arg_bytecode <- compiler::cmpfun(arg)
+
+  expect_identical(arg(), quo("foobar"))
+  expect_identical(arg_bytecode(), quo("foobar"))
+
+  dots <- function() {
+    quos("foo", "bar")
+  }
+  dots_bytecode <- compiler::cmpfun(dots)
+
+  expect_identical(dots(), quos("foo", "bar"))
+  expect_identical(dots_bytecode(), quos("foo", "bar"))
+})


### PR DESCRIPTION
This fixes the "Argument was already evaluated" error of the lisy and epidata packages.

This one is kind of serious. Should we make another rlang release before dplyr's?

cc @krlmlr 