### PR TITLE
enquo() as alias to quo() when called at top-level

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,10 @@
 
 * New `fn_fmls<-` and `fn_fmls_names<-` setters.
 
+* Calling `enquo()` at top-level is now an alias for `quo()` instead
+  of throwing an error. This is intended to make it easier to teach
+  tidyeval.
+
 
 # rlang 0.1.1
 

--- a/R/quo.R
+++ b/R/quo.R
@@ -194,10 +194,14 @@ enquo <- function(arg) {
     return(new_quosure(missing_arg(), empty_env()))
   }
 
-  capture <- lang(captureArg, substitute(arg))
-  arg <- eval_bare(capture, caller_env())
-  expr <- .Call(rlang_interp, arg$expr, arg$env, TRUE)
-  forward_quosure(expr, arg$env)
+  if (sys.parent() == 0) {
+    enquo(arg)
+  } else {
+    capture <- lang(captureArg, substitute(arg))
+    arg <- eval_bare(capture, caller_env())
+    expr <- .Call(rlang_interp, arg$expr, arg$env, TRUE)
+    forward_quosure(expr, arg$env)
+  }
 }
 forward_quosure <- function(expr, env) {
   if (is_quosure(expr)) {


### PR DESCRIPTION
~~lncludes a review of the call stack UI as I got confused by a simple `call_depth()` (even though I ended up using `sys.parent()` to make the top-level check).~~ This is now in #197
