### PR TITLE
Make stack UI more consistent

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,10 @@
 
 * New `fn_fmls<-` and `fn_fmls_names<-` setters.
 
+* The `n` argument of the stack and frame function has been reviewed
+  to make it more intuitive. Now `n = 0` refers to the current frame,
+  `n = 1` to the previous frame, etc.
+
 
 # rlang 0.1.1
 

--- a/man/caller_env.Rd
+++ b/man/caller_env.Rd
@@ -18,9 +18,9 @@ to \code{\link[=call_frame]{call_frame()}}, 1 represents the parent frame rather
 current frame.}
 }
 \description{
-\code{caller_frame()} is a shortcut for \code{call_frame(2)} and
+\code{caller_frame()} is a shortcut for \code{call_frame(1)} and
 \code{caller_fn()} and \code{caller_env()} are shortcuts for
-\code{call_frame(2)$env} \code{call_frame(2)$fn}.
+\code{call_frame(1)$env} \code{call_frame(1)$fn}.
 }
 \seealso{
 \code{\link[=call_frame]{call_frame()}}

--- a/man/stack.Rd
+++ b/man/stack.Rd
@@ -16,9 +16,9 @@ global_frame()
 
 current_frame()
 
-ctxt_frame(n = 1)
+ctxt_frame(n = 0)
 
-call_frame(n = 1, clean = TRUE)
+call_frame(n = 0, clean = TRUE)
 
 ctxt_depth()
 
@@ -29,7 +29,8 @@ ctxt_stack(n = NULL, trim = 0)
 call_stack(n = NULL, clean = TRUE)
 }
 \arguments{
-\item{n}{The number of frames to go back in the stack.}
+\item{n}{The number of frames to go back in the stack. 0 refers to
+the current frame on the stack, 1 to the previous frame, etc.}
 
 \item{clean}{Whether to post-process the call stack to clean
 non-standard frames. If \code{TRUE}, suboptimal call-stack entries by
@@ -67,20 +68,8 @@ with \code{n = 1} referring to the current context. The \code{which} argument
 is more complicated and changes meaning for values lower than 1.
 For the sake of consistency, the lazyeval functions all take the
 same kind of argument \code{n}. This argument has a single meaning (the
-number of frames to go down the stack) and cannot be lower than 1.
-
-Note finally that \code{parent.frame(1)} corresponds to
-\code{call_frame(2)$env}, as \code{n = 1} always refers to the current
-frame. This makes the \code{_frame()} and \code{_stack()} functions
-consistent: \code{ctxt_frame(2)} is the same as \code{ctxt_stack()[[2]]}.
-Also, \code{ctxt_depth()} returns one more frame than
-[base::sys.nframe()] because it counts the global frame. That is
-consistent with the \code{_stack()} functions which return the global
-frame as well. This way, \code{call_stack(call_depth())} is the same as
-\code{global_frame()}.
-
-[[2]: R:[2
-[base::sys.nframe()]: R:base::sys.nframe()
+number of frames to go down the stack) and cannot be lower than 0,
+with 0 referring to the current context.
 }
 \examples{
 # Expressions within arguments count as contexts
@@ -109,8 +98,8 @@ f(g(call_stack))
 # purrr::map(stack, "env")
 # purrr::transpose(stack)$expr
 
-# current_frame() is an alias for ctxt_frame(1)
-fn <- function() list(current = current_frame(), first = ctxt_frame(1))
+# current_frame() is an alias for ctxt_frame(0)
+fn <- function() list(current = current_frame(), first = ctxt_frame(0))
 fn()
 
 # While current_frame() is the top of the stack, global_frame() is

--- a/tests/testthat/test-stack.R
+++ b/tests/testthat/test-stack.R
@@ -58,7 +58,7 @@ test_that("call_depth() returns correct depth", {
 })
 
 test_that("call_frame()$env is the same as parent.frame()", {
-  f <- function(n) call_frame(n + 1)$env
+  f <- function(n) call_frame(n)$env
   f_base <- function(n) parent.frame(n)
   env1 <- f(1)
   env1_base <- f_base(1)
@@ -70,10 +70,10 @@ test_that("call_frame()$env is the same as parent.frame()", {
 })
 
 test_that("call_frame()$expr gives expression of caller not previous ctxt", {
-  f <- function(x = 1) call_frame(x)$expr
+  f <- function(x = 0) call_frame(x)$expr
   expect_equal(f(), quote(f()))
 
-  g <- function() identity(f(2))
+  g <- function() identity(f(1))
   expect_equal(g(), quote(g()))
 })
 
@@ -194,12 +194,12 @@ test_that("ctxt_stack() subsets n frames", {
   expect_identical(stack_2, stack[1:2])
 
   n <- ctxt_depth()
-  stack_n <- ctxt_stack(n)
+  stack_n <- ctxt_stack(n + 1)
   expect_identical(stack_n, stack)
 
   # Get correct eval depth within expect_error()
   expect_error({ n <- ctxt_depth(); stop() })
-  expect_error(ctxt_stack(n + 1), "not that many frames")
+  expect_error(ctxt_stack(n + 2), "not that many frames")
 })
 
 test_that("call_stack() subsets n frames", {
@@ -208,12 +208,14 @@ test_that("call_stack() subsets n frames", {
   expect_identical(stack_2, stack[1:2])
 
   n <- call_depth()
-  stack_n <- call_stack(n)
+  stack_n <- call_stack(n + 1)
   expect_identical(stack_n, stack)
 
   # Get correct eval depth within expect_error()
   expect_error({ n <- call_depth(); stop() })
-  expect_error(call_stack(n + 1), "not that many frames")
+
+  # Add 1 for the global frame + 1 to get out of bound
+  expect_error(call_stack(n + 2), "not that many frames")
 })
 
 test_that("call stacks are cleaned", {

--- a/tests/testthat/test-stack.R
+++ b/tests/testthat/test-stack.R
@@ -312,6 +312,7 @@ test_that("can return to frame", {
 
 test_that("detects frame environment", {
   expect_true(identity(is_frame_env(ctxt_frame(2)$env)))
+  expect_false(is_frame_env(env()))
 })
 
 test_that("call is not modified in place", {


### PR DESCRIPTION
Extracted from #189 

- `n = 0` now refers to the current frame rather than `n = 1`.
- `call_depth()` and `ctxt_depth()` called at top-level now return 0.