### PR TITLE
Fix couple of bugs before release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,11 @@
   a call depth as `call` arguments. This allows plucking a call from
   further up the call stack (#30).
 
+* `cnd_signal()` now returns invisibly.
+
+* `cnd_signal()` and `cnd_abort()` now accept character vectors to
+  create typed conditions with several S3 subclasses.
+
 * New `env_set()` function to set a value in an environment or a
   scope. If the `create` argument is `FALSE`, it only overwrites
   existing bindings and issues an error otherwise (#162).

--- a/R/cnd.R
+++ b/R/cnd.R
@@ -221,14 +221,14 @@ is_condition <- function(x) {
 cnd_signal <- function(.cnd, ..., .msg = NULL, .call = NULL,
                        .mufflable = TRUE) {
   cnd <- cnd_update(.cnd, ..., .msg = .msg, .call = cnd_call(.call), .show_call = .call)
-  .Call(rlang_cnd_signal, cnd, .mufflable)
+  invisible(.Call(rlang_cnd_signal, cnd, .mufflable))
 }
 #' @rdname cnd_signal
 #' @export
 cnd_abort <- function(.cnd, ..., .msg = NULL, .call = NULL,
                       .mufflable = FALSE) {
   cnd <- cnd_update(.cnd, ..., .msg = .msg, .call = cnd_call(.call), .show_call = .call)
-  .Call(rlang_cnd_signal_error, cnd, .mufflable)
+  invisible(.Call(rlang_cnd_signal_error, cnd, .mufflable))
 }
 
 cnd_call <- function(call) {

--- a/R/cnd.R
+++ b/R/cnd.R
@@ -241,7 +241,7 @@ cnd_call <- function(call) {
   caller_frame(call + 1)$expr
 }
 cnd_update <- function(.cnd, ..., .msg, .call, .show_call) {
-  if (is_string(.cnd)) {
+  if (is_character(.cnd)) {
     .cnd <- cnd(.cnd, ...)
   } else {
     stopifnot(is_condition(.cnd))

--- a/R/eval-tidy.R
+++ b/R/eval-tidy.R
@@ -91,10 +91,6 @@
 #' eval_tidy(quo(!! cyl), mtcars)
 #' @name eval_tidy
 eval_tidy <- function(expr, data = NULL, env = caller_env()) {
-  if (is_list(expr)) {
-    return(map(expr, eval_tidy, data = data))
-  }
-
   if (!inherits(expr, "quosure")) {
     expr <- new_quosure(expr, env)
   }

--- a/src/cnd.c
+++ b/src/cnd.c
@@ -136,9 +136,9 @@ void cnd_signal_error(SEXP cnd, bool mufflable) {
 
 SEXP rlang_cnd_signal(SEXP cnd, SEXP mufflable) {
   cnd_signal(cnd, r_as_bool(mufflable));
-  return cnd;
+  return R_NilValue;
 }
 SEXP rlang_cnd_signal_error(SEXP cnd, SEXP mufflable) {
   cnd_signal_error(cnd, r_as_bool(mufflable));
-  return cnd;
+  return R_NilValue;
 }

--- a/tests/testthat/test-conditions.R
+++ b/tests/testthat/test-conditions.R
@@ -168,3 +168,7 @@ test_that("restarting() handlers pass along all requested arguments", {
   }
   with_restarts(fn(), rst_foo = rst_foo)
 })
+
+test_that("cnd_signal() returns NULL invisibly", {
+  expect_identical(withVisible(cnd_signal("foo")), withVisible(invisible(NULL)))
+})

--- a/tests/testthat/test-conditions.R
+++ b/tests/testthat/test-conditions.R
@@ -172,3 +172,10 @@ test_that("restarting() handlers pass along all requested arguments", {
 test_that("cnd_signal() returns NULL invisibly", {
   expect_identical(withVisible(cnd_signal("foo")), withVisible(invisible(NULL)))
 })
+
+test_that("cnd_signal() accepts character vectors (#195)", {
+  expect <- inplace(function(cnd) {
+    expect_identical(class(cnd), c("mufflable", "foo", "bar", "condition"))
+  })
+  with_handlers(cnd_signal(c("foo", "bar")), foo = expect)
+})


### PR DESCRIPTION
- `eval_tidy()` does not map over lists anymore.
- `cnd_signal()` accepts character vectors of S3 classes and returns `NULL` invisibly.