### PR TITLE
Fix .env pronoun

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,15 @@
   serialised to unicode point form (e.g. `<U+xxxx>`) to UTF-8. In
   addition, `as_utf8_character()` now translates those as well.
 
+* `eval_tidy()` no longer maps over lists but returns them literally.
+  This behaviour is an overlook from past refactorings and was never
+  documented.
+
+* When nested quosures are evaluated with `eval_tidy()`, the `.env`
+  pronoun now correctly refers to the current quosure under evaluation
+  (#174). Previously it would always refer to the environment of the
+  outermost quosure.
+
 
 # rlang 0.1.1
 

--- a/src/env.c
+++ b/src/env.c
@@ -20,6 +20,10 @@ bool r_is_env(SEXP x) {
 SEXP r_env_get(SEXP env, SEXP sym) {
   return Rf_findVarInFrame3(env, sym, TRUE);
 }
+SEXP r_env_set(SEXP env, SEXP sym, SEXP value) {
+  Rf_defineVar(sym, value, env);
+  return env;
+}
 
 SEXP r_ns_env(const char* pkg) {
   SEXP ns = r_env_get(R_NamespaceRegistry, r_sym(pkg));

--- a/src/env.h
+++ b/src/env.h
@@ -11,6 +11,7 @@ bool r_is_unbound_value(SEXP x);
 void r_mut_env_parent(SEXP env, SEXP new_parent);
 bool r_is_env(SEXP x);
 SEXP r_env_get(SEXP env, SEXP sym);
+SEXP r_env_set(SEXP env, SEXP sym, SEXP value);
 SEXP r_ns_env(const char* pkg);
 
 

--- a/src/eval-tidy.c
+++ b/src/eval-tidy.c
@@ -1,7 +1,7 @@
 #include "rlang.h"
 
 static
-SEXP base_tilde_eval(SEXP tilde, SEXP env) {
+SEXP base_tilde_eval(SEXP tilde, SEXP quo_env) {
   if (r_f_has_env(tilde))
     return tilde;
 
@@ -15,7 +15,7 @@ SEXP base_tilde_eval(SEXP tilde, SEXP env) {
   // Inline the base primitive because overscopes override `~` to make
   // quosures self-evaluate
   tilde = KEEP(r_new_language_(tilde_prim, r_node_cdr(tilde)));
-  tilde = KEEP(r_eval(tilde, env));
+  tilde = KEEP(r_eval(tilde, quo_env));
 
   // Change it back because the result still has the primitive inlined
   r_mut_node_car(tilde, tilde_sym);
@@ -31,18 +31,27 @@ SEXP rlang_tilde_eval(SEXP tilde, SEXP overscope, SEXP overscope_top, SEXP cur_f
   if (r_quo_is_missing(tilde))
     return(r_missing_arg());
 
-  SEXP env = r_f_env(tilde);
+  SEXP quo_env = r_f_env(tilde);
   SEXP prev_env = r_env_get(overscope, r_sym(".env"));
-  if (r_is_null(env))
-    env = prev_env;
+  if (r_is_null(quo_env))
+    quo_env = prev_env;
 
   // Swap enclosures temporarily by rechaining the top of the dynamic
   // scope to the enclosure of the new formula, if it has one
-  r_mut_env_parent(overscope_top, env);
+  r_mut_env_parent(overscope_top, quo_env);
 
   SEXP exit_fun = rlang_obj("mut_env_parent");
   SEXP exit_args = r_new_pairlist2(overscope_top, prev_env);
   SEXP exit_lang = KEEP(r_new_language(exit_fun, exit_args));
+  r_on_exit(exit_lang, cur_frame);
+  FREE(1);
+
+  // Update .env pronoun to current quosure env temporarily
+  r_env_set(overscope, r_sym(".env"), quo_env);
+
+  exit_fun = rlang_obj("env_set");
+  exit_args = r_new_pairlist3(overscope, string(".env"), prev_env);
+  exit_lang = KEEP(r_new_language(exit_fun, exit_args));
   r_on_exit(exit_lang, cur_frame);
   FREE(1);
 

--- a/tests/testthat/test-tidy-eval.R
+++ b/tests/testthat/test-tidy-eval.R
@@ -215,3 +215,17 @@ test_that("tilde calls are evaluated in overscope", {
   f <- eval_tidy(quo)
   expect_true(env_has(f, "foo"))
 })
+
+test_that(".env pronoun refers to current quosure (#174)", {
+  inner_quo <- local({
+    var <- "inner"
+    quo(.env$var)
+  })
+
+  outer_quo <- local({
+    var <- "outer"
+    quo(identity(!! inner_quo))
+  })
+
+  expect_identical(eval_tidy(outer_quo), "inner")
+})


### PR DESCRIPTION
The `.env` pronoun should refer to the current quosure env. Closes #174.