### PR TITLE
Add a Makevars file for unity builds

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,0 +1,31 @@
+files = rlang/rlang.h \
+        rlang/attrs.c \
+        rlang/cnd.c \
+        rlang/env.c \
+        rlang/eval.c \
+        rlang/export.c \
+        rlang/expr-interp.c \
+        rlang/formula.c \
+        rlang/lang.c \
+        rlang/node.c \
+        rlang/quo.c \
+        rlang/replace-na.c \
+        rlang/sexp.c \
+        rlang/squash.c \
+        rlang/stack.c \
+        rlang/sym.c \
+        rlang/sym-unescape.c \
+        rlang/utils.c \
+        rlang/vector.c \
+        rlang/vector-chr.c \
+        rlang/vector-lgl.c \
+        rlang/vector-list.c
+
+all: $(SHLIB)
+
+$(SHLIB): rlang.c
+
+rlang.c: $(files)
+	touch rlang.c
+
+.PHONY: all


### PR DESCRIPTION
This forces 'rlang.c' to be recompiled if any of it's dependencies are out
of date.

Rather than requiring pkgbuild modifications an easier solution might be to use a Makevars which handles the dependency resolution.

Taking this idea further could have `rlang.c` written based on the `files` variable in the Makevars, which would remove the redundant filenames. You could also populate `files` with wildcards so they wouldn't have to be listed explicitly, but this requires GNU make extensions.

Fixes https://github.com/r-lib/pkgload/issues/50, https://github.com/r-lib/pkgbuild/pull/13