### PR TITLE
Ensure that is_integerish() heeds length requirement

### DIFF
--- a/R/types.R
+++ b/R/types.R
@@ -288,11 +288,11 @@ is_false <- function(x) {
 #' @examples
 #' is_integerish(10L)
 #' is_integerish(10.0)
+#' is_integerish(10.0, n = 2)
 #' is_integerish(10.000001)
 #' is_integerish(TRUE)
 is_integerish <- function(x, n = NULL) {
-  if (typeof(x) == "integer") return(TRUE)
-  if (typeof(x) != "double") return(FALSE)
+  if (!typeof(x) %in% c("double", "integer")) return(FALSE)
   if (!is_null(n) && length(x) != n) return(FALSE)
   all(x == as.integer(x))
 }

--- a/man/is_integerish.Rd
+++ b/man/is_integerish.Rd
@@ -27,6 +27,7 @@ of how to check for whole numbers.
 \examples{
 is_integerish(10L)
 is_integerish(10.0)
+is_integerish(10.0, n = 2)
 is_integerish(10.000001)
 is_integerish(TRUE)
 }

--- a/tests/testthat/test-types.R
+++ b/tests/testthat/test-types.R
@@ -57,3 +57,22 @@ test_that("types are friendly", {
   expect_identical(friendly_type("integer"), "an integer vector")
   expect_identical(friendly_type("language"), "a call")
 })
+
+test_that("is_integerish() heeds type requirement", {
+  for (n in 0:2) {
+    expect_true(is_integerish(integer(n)))
+    expect_true(is_integerish(double(n)))
+    expect_false(is_integerish(double(n + 1) + .000001))
+  }
+
+  types <- c("logical", "complex", "character", "expression", "list", "raw")
+  for (type in types)
+    expect_false(is_integerish(vector(type)))
+})
+
+test_that("is_integerish() heeds length requirement", {
+  for (n in 0:2) {
+    expect_true(is_integerish(double(n), n = n))
+    expect_false(is_integerish(double(n), n = n + 1))
+  }
+})


### PR DESCRIPTION
Previously, `is_integerish(x, n)` would disregard `n` for `x` an integer vector.