### PR TITLE
Simplification of scalar predicates

### DIFF
--- a/R/types.R
+++ b/R/types.R
@@ -107,42 +107,42 @@ NULL
 #' @export
 #' @rdname scalar-type-predicates
 is_scalar_list <- function(x) {
-  is_list(x) && length(x) == 1
+  is_list(x, n = 1)
 }
 #' @export
 #' @rdname scalar-type-predicates
 is_scalar_atomic <- function(x) {
-  is_atomic(x) && length(x) == 1
+  is_atomic(x, n = 1)
 }
 #' @export
 #' @rdname scalar-type-predicates
 is_scalar_vector <- function(x) {
-  is_vector(x) && length(x) == 1
+  is_vector(x, n = 1)
 }
 #' @export
 #' @rdname scalar-type-predicates
 is_scalar_integer <- function(x) {
-  is_integer(x) && length(x) == 1
+  is_integer(x, n = 1)
 }
 #' @export
 #' @rdname scalar-type-predicates
 is_scalar_double <- function(x) {
-  is_double(x) && length(x) == 1
+  is_double(x, n = 1)
 }
 #' @export
 #' @rdname scalar-type-predicates
 is_scalar_character <- function(x, encoding = NULL) {
-  is_character(x, encoding = encoding) && length(x) == 1
+  is_character(x, encoding = encoding, n = 1)
 }
 #' @export
 #' @rdname scalar-type-predicates
 is_scalar_logical <- function(x) {
-  is_logical(x) && length(x) == 1
+  is_logical(x, n = 1)
 }
 #' @export
 #' @rdname scalar-type-predicates
 is_scalar_raw <- function(x) {
-  is_raw(x) && length(x) == 1
+  is_raw(x, n = 1)
 }
 #' @export
 #' @rdname scalar-type-predicates

--- a/tests/testthat/test-types.R
+++ b/tests/testthat/test-types.R
@@ -76,3 +76,23 @@ test_that("is_integerish() heeds length requirement", {
     expect_false(is_integerish(double(n), n = n + 1))
   }
 })
+
+test_that("scalar predicates heed type and length", {
+  expect_true_false <- function(pred, pass, fail_len, fail_type) {
+    expect_true(pred(pass))
+    expect_false(pred(fail_len))
+    expect_false(pred(fail_type))
+  }
+
+  expect_true_false(is_scalar_list, list(1), list(1, 2), logical(1))
+  expect_true_false(is_scalar_atomic, logical(1), logical(2), list(1))
+  expect_true_false(is_scalar_vector, list(1), list(1, 2), quote(x))
+  expect_true_false(is_scalar_vector, logical(1), logical(2), function() {})
+  expect_true_false(is_scalar_integer, integer(1), integer(2), double(1))
+  expect_true_false(is_scalar_double, double(1), double(2), integer(1))
+  expect_true_false(is_scalar_character, character(1), character(2), logical(1))
+  expect_true_false(is_string, character(1), character(2), logical(1))
+  expect_true_false(is_scalar_logical, logical(1), logical(2), character(1))
+  expect_true_false(is_scalar_raw, raw(1), raw(2), NULL)
+  expect_true_false(is_scalar_bytes, raw(1), raw(2), NULL)
+})


### PR DESCRIPTION
Minor edit of `is_*(x) && length(x) == 1` to `is_*(x, n = 1)`, in bodies of scalar predicates.