### PR TITLE
fix typos in the man page of `quosure`: absence of space

### DIFF
--- a/R/quo.R
+++ b/R/quo.R
@@ -3,8 +3,8 @@
 #' @description
 #'
 #' Quosures are quoted [expressions][is_expr] that keep track of an
-#' [environment][env] (just like [closure
-#' functions](http://adv-r.had.co.nz/Functional-programming.html#closures)).
+#' [environment][env] (just like
+#' [closure functions](http://adv-r.had.co.nz/Functional-programming.html#closures)).
 #' They are implemented as a subclass of one-sided formulas. They are
 #' an essential piece of the tidy evaluation framework.
 #'
@@ -47,10 +47,10 @@
 #'   quosure inside another quosure and evaluate it like you've
 #'   unquoted a raw expression.
 #'
-#' See the [programming with
-#' dplyr](http://dplyr.tidyverse.org/articles/programming.html)
-#' vignette for practical examples. For developers, the [tidy
-#' evaluation](http://rlang.tidyverse.org/articles/tidy-evaluation.html)
+#' See the
+#' [programming with dplyr](http://dplyr.tidyverse.org/articles/programming.html)
+#' vignette for practical examples. For developers, the
+#' [tidy evaluation](http://rlang.tidyverse.org/articles/tidy-evaluation.html)
 #' vignette provides an overview of this approach. The
 #' [quasiquotation] page goes in detail over the unquoting and
 #' splicing operators.

--- a/man/quosure.Rd
+++ b/man/quosure.Rd
@@ -28,7 +28,8 @@ expression supplied as argument.
 }
 \description{
 Quosures are quoted \link[=is_expr]{expressions} that keep track of an
-\link[=env]{environment} (just like \href{http://adv-r.had.co.nz/Functional-programming.html#closures}{closurefunctions}).
+\link[=env]{environment} (just like
+\href{http://adv-r.had.co.nz/Functional-programming.html#closures}{closure functions}).
 They are implemented as a subclass of one-sided formulas. They are
 an essential piece of the tidy evaluation framework.
 \itemize{
@@ -69,8 +70,10 @@ quosure inside another quosure and evaluate it like you've
 unquoted a raw expression.
 }
 
-See the \href{http://dplyr.tidyverse.org/articles/programming.html}{programming withdplyr}
-vignette for practical examples. For developers, the \href{http://rlang.tidyverse.org/articles/tidy-evaluation.html}{tidyevaluation}
+See the
+\href{http://dplyr.tidyverse.org/articles/programming.html}{programming with dplyr}
+vignette for practical examples. For developers, the
+\href{http://rlang.tidyverse.org/articles/tidy-evaluation.html}{tidy evaluation}
 vignette provides an overview of this approach. The
 \link{quasiquotation} page goes in detail over the unquoting and
 splicing operators.


### PR DESCRIPTION
absence of space 