### PR TITLE
Better handling of non-finite values in numeric predicates

### DIFF
--- a/R/types.R
+++ b/R/types.R
@@ -18,6 +18,8 @@
 #'
 #' @param x Object to be tested.
 #' @param n Expected length of a vector.
+#' @param finite Whether values must be finite. Examples of non-finite
+#'   values are `Inf`, `-Inf` and `NaN`.
 #' @param encoding Expected encoding of a string or character
 #'   vector. One of `UTF-8`, `latin1`, or `unknown`.
 #' @seealso [bare-type-predicates] [scalar-type-predicates]
@@ -56,9 +58,18 @@ is_integer <- function(x, n = NULL) {
 }
 #' @export
 #' @rdname type-predicates
-is_double <- function(x, n = NULL) {
+is_double <- function(x, n = NULL, finite = NULL) {
   if (typeof(x) != "double") return(FALSE)
   if (!is_null(n) && length(x) != n) return(FALSE)
+
+  if (!is_null(finite)) {
+    if (finite) {
+      return(all(is.finite(x)))
+    } else {
+      return(!any(is.finite(x)))
+    }
+  }
+
   TRUE
 }
 #' @export
@@ -291,11 +302,18 @@ is_false <- function(x) {
 #' is_integerish(10.0, n = 2)
 #' is_integerish(10.000001)
 #' is_integerish(TRUE)
-is_integerish <- function(x, n = NULL) {
+is_integerish <- function(x, n = NULL, finite = NULL) {
   if (!typeof(x) %in% c("double", "integer")) return(FALSE)
   if (!is_null(n) && length(x) != n) return(FALSE)
 
-  x_finite <- x[is.finite(x)]
+  finite_elts <- is.finite(x)
+  if (is_true(finite) && !all(finite_elts)) {
+    return(FALSE)
+  } else if (is_false(finite)) {
+    return(!any(finite_elts))
+  }
+
+  x_finite <- x[finite_elts]
   all(x_finite == as.integer(x_finite))
 }
 #' @rdname is_integerish

--- a/R/types.R
+++ b/R/types.R
@@ -302,18 +302,19 @@ is_false <- function(x) {
 #' is_integerish(10.0, n = 2)
 #' is_integerish(10.000001)
 #' is_integerish(TRUE)
-is_integerish <- function(x, n = NULL, finite = NULL) {
+is_integerish <- function(x, n = NULL, finite = TRUE) {
   if (!typeof(x) %in% c("double", "integer")) return(FALSE)
   if (!is_null(n) && length(x) != n) return(FALSE)
 
-  finite_elts <- is.finite(x)
+  missing_elts <- is.na(x)
+  finite_elts <- is.finite(x) | missing_elts
   if (is_true(finite) && !all(finite_elts)) {
     return(FALSE)
   } else if (is_false(finite)) {
     return(!any(finite_elts))
   }
 
-  x_finite <- x[finite_elts]
+  x_finite <- x[finite_elts & !missing_elts]
   all(x_finite == as.integer(x_finite))
 }
 #' @rdname is_integerish

--- a/R/types.R
+++ b/R/types.R
@@ -294,7 +294,9 @@ is_false <- function(x) {
 is_integerish <- function(x, n = NULL) {
   if (!typeof(x) %in% c("double", "integer")) return(FALSE)
   if (!is_null(n) && length(x) != n) return(FALSE)
-  all(x == as.integer(x))
+
+  x_finite <- x[is.finite(x)]
+  all(x_finite == as.integer(x_finite))
 }
 #' @rdname is_integerish
 #' @export

--- a/man/is_integerish.Rd
+++ b/man/is_integerish.Rd
@@ -6,7 +6,7 @@
 \alias{is_scalar_integerish}
 \title{Is a vector integer-like?}
 \usage{
-is_integerish(x, n = NULL, finite = NULL)
+is_integerish(x, n = NULL, finite = TRUE)
 
 is_bare_integerish(x, n = NULL)
 

--- a/man/is_integerish.Rd
+++ b/man/is_integerish.Rd
@@ -6,7 +6,7 @@
 \alias{is_scalar_integerish}
 \title{Is a vector integer-like?}
 \usage{
-is_integerish(x, n = NULL)
+is_integerish(x, n = NULL, finite = NULL)
 
 is_bare_integerish(x, n = NULL)
 
@@ -16,6 +16,9 @@ is_scalar_integerish(x)
 \item{x}{Object to be tested.}
 
 \item{n}{Expected length of a vector.}
+
+\item{finite}{Whether values must be finite. Examples of non-finite
+values are \code{Inf}, \code{-Inf} and \code{NaN}.}
 }
 \description{
 These predicates check whether R considers a number vector to be

--- a/man/type-predicates.Rd
+++ b/man/type-predicates.Rd
@@ -22,7 +22,7 @@ is_vector(x, n = NULL)
 
 is_integer(x, n = NULL)
 
-is_double(x, n = NULL)
+is_double(x, n = NULL, finite = NULL)
 
 is_character(x, n = NULL, encoding = NULL)
 
@@ -38,6 +38,9 @@ is_null(x)
 \item{x}{Object to be tested.}
 
 \item{n}{Expected length of a vector.}
+
+\item{finite}{Whether values must be finite. Examples of non-finite
+values are \code{Inf}, \code{-Inf} and \code{NaN}.}
 
 \item{encoding}{Expected encoding of a string or character
 vector. One of \code{UTF-8}, \code{latin1}, or \code{unknown}.}

--- a/tests/testthat/test-types.R
+++ b/tests/testthat/test-types.R
@@ -66,8 +66,9 @@ test_that("is_integerish() heeds type requirement", {
   }
 
   types <- c("logical", "complex", "character", "expression", "list", "raw")
-  for (type in types)
+  for (type in types) {
     expect_false(is_integerish(vector(type)))
+  }
 })
 
 test_that("is_integerish() heeds length requirement", {
@@ -75,6 +76,12 @@ test_that("is_integerish() heeds length requirement", {
     expect_true(is_integerish(double(n), n = n))
     expect_false(is_integerish(double(n), n = n + 1))
   }
+})
+
+test_that("non finite double values are integerish", {
+  expect_true(is_integerish(dbl(1, Inf, -Inf, NaN)))
+  expect_true(is_integerish(dbl(1, NA)))
+  expect_true(is_integerish(int(1, NA)))
 })
 
 test_that("scalar predicates heed type and length", {

--- a/tests/testthat/test-types.R
+++ b/tests/testthat/test-types.R
@@ -79,7 +79,7 @@ test_that("is_integerish() heeds length requirement", {
 })
 
 test_that("non finite double values are integerish", {
-  expect_true(is_integerish(dbl(1, Inf, -Inf, NaN)))
+  expect_true(is_integerish(dbl(1, Inf, -Inf, NaN), finite = NULL))
   expect_true(is_integerish(dbl(1, NA)))
   expect_true(is_integerish(int(1, NA)))
 })

--- a/tests/testthat/test-types.R
+++ b/tests/testthat/test-types.R
@@ -84,6 +84,20 @@ test_that("non finite double values are integerish", {
   expect_true(is_integerish(int(1, NA)))
 })
 
+test_that("check finiteness", {
+  expect_true(    is_double(dbl(1, 2), finite = TRUE))
+  expect_true(is_integerish(dbl(1, 2), finite = TRUE))
+
+  expect_false(    is_double(dbl(1, Inf), finite = TRUE))
+  expect_false(is_integerish(dbl(1, Inf), finite = TRUE))
+
+  expect_false(    is_double(dbl(1, Inf), finite = FALSE))
+  expect_false(is_integerish(dbl(1, Inf), finite = FALSE))
+
+  expect_true(    is_double(dbl(-Inf, Inf), finite = FALSE))
+  expect_true(is_integerish(dbl(-Inf, Inf), finite = FALSE))
+})
+
 test_that("scalar predicates heed type and length", {
   expect_true_false <- function(pred, pass, fail_len, fail_type) {
     expect_true(pred(pass))


### PR DESCRIPTION
- `is_integerish(c(Inf, -Inf, NaN))` now returns `TRUE`

- There is a new `finite` argument for `is_integerish()` and `is_double()` to check whether all values are finite.