### PR TITLE
Deep unquoting of names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -75,7 +75,9 @@
 
 * `exprs()` and `quos()` gain a `.unquote_names` arguments to switch
   off interpretation of `:=` as a name operator. This should be useful
-  for programming on the language targetting APIs such as data.table.
+  for programming on the language targetting APIs such as
+  data.table. For consistency `dots_list()` and `dots_splice()` gain
+  that argument as well.
 
 * The backend for `quos()`, `exprs()`, `dots_list()`, etc is now
   written in C. This greatly improve the performance of dots capture,

--- a/NEWS.md
+++ b/NEWS.md
@@ -79,6 +79,13 @@
   data.table. For consistency `dots_list()` and `dots_splice()` gain
   that argument as well.
 
+* Quoting operators now treats the `:=` operator as a synonym of `=`
+  in the whole expression rather than just at the root. This way
+  `expr(list(a := 1))` is a synonym of `expr(list(a = 1))`. As usual
+  you can unquote names with `!!` on the LHS of `:=`. `enexpr()` and
+  `enquo()` gain an `unquote_names` argument to disable this behaviour
+  (which is useful if you're targetting DSLs such as data.table).
+
 * The backend for `quos()`, `exprs()`, `dots_list()`, etc is now
   written in C. This greatly improve the performance of dots capture,
   especially with the splicing operator `!!!` which now scales much

--- a/R/dots.R
+++ b/R/dots.R
@@ -11,7 +11,7 @@
 #' splicing semantics_: in addition to lists marked explicitly for
 #' splicing, [bare][is_bare_list] lists are spliced as well.
 #'
-#' @inheritParams dots_values
+#' @inheritParams quosures
 #' @param ... Arguments with explicit (`dots_list()`) or list
 #'   (`dots_splice()`) splicing semantics. The contents of spliced
 #'   arguments are embedded in the returned list.
@@ -39,8 +39,10 @@
 #' # as it will match `fn`'s `data` argument. The splicing syntax
 #' # provides a workaround:
 #' fn(some_data, !!! list(data = letters))
-dots_list <- function(..., .ignore_empty = c("trailing", "none", "all")) {
-  dots <- .Call(rlang_dots_list, environment(), FALSE, .ignore_empty)
+dots_list <- function(...,
+                      .ignore_empty = c("trailing", "none", "all"),
+                      .unquote_names = TRUE) {
+  dots <- .Call(rlang_dots_list, environment(), FALSE, .ignore_empty, .unquote_names)
   names(dots) <- names2(dots)
   dots
 }
@@ -53,8 +55,10 @@ dots_list <- function(..., .ignore_empty = c("trailing", "none", "all")) {
 #' x <- list(1, 2)
 #' dots_splice(!!! x, 3)
 #' dots_splice(x, 3)
-dots_splice <- function(..., .ignore_empty = c("trailing", "none", "all")) {
-  dots <- .Call(rlang_dots_flat_list, environment(), FALSE, .ignore_empty)
+dots_splice <- function(...,
+                        .ignore_empty = c("trailing", "none", "all"),
+                        .unquote_names = TRUE) {
+  dots <- .Call(rlang_dots_flat_list, environment(), FALSE, .ignore_empty, .unquote_names)
   names(dots) <- names2(dots)
   dots
 }
@@ -68,10 +72,8 @@ dots_splice <- function(..., .ignore_empty = c("trailing", "none", "all")) {
 #' [splice()]). You can process spliced objects manually, perhaps with
 #' a custom predicate (see [flatten_if()]).
 #'
+#' @inheritParams quosures
 #' @param ... Arguments to evaluate and process splicing operators.
-#' @param .ignore_empty Whether to ignore empty arguments. Can be one
-#'   of `"trailing"`, `"none"`, `"all"`. If `"trailing"`, only the
-#'   last argument is ignored if it is empty.
 #' @export
 #' @examples
 #' dots <- dots_values(!!! list(1))
@@ -79,8 +81,10 @@ dots_splice <- function(..., .ignore_empty = c("trailing", "none", "all")) {
 #'
 #' # Flatten the spliced objects:
 #' flatten_if(dots, is_spliced)
-dots_values <- function(..., .ignore_empty = c("trailing", "none", "all")) {
-  .Call(rlang_dots_values, environment(), FALSE, .ignore_empty)
+dots_values <- function(...,
+                        .ignore_empty = c("trailing", "none", "all"),
+                        .unquote_names = TRUE) {
+  .Call(rlang_dots_values, environment(), FALSE, .ignore_empty, .unquote_names)
 }
 
 #' @rdname quosures

--- a/R/expr.R
+++ b/R/expr.R
@@ -62,13 +62,13 @@ expr <- function(expr) {
   enexpr(expr)
 }
 #' @rdname expr
+#' @inheritParams quosures
 #' @export
-enexpr <- function(arg) {
-  .Call(rlang_enexpr, substitute(arg), parent.frame())
+enexpr <- function(arg, unquote_names = TRUE) {
+  .Call(rlang_enexpr, substitute(arg), parent.frame(), unquote_names)
 }
 #' @rdname expr
 #' @inheritParams quosures
-#' @inheritParams dots_values
 #' @param ... Arguments to extract.
 #' @export
 exprs <- function(...,

--- a/R/quo.R
+++ b/R/quo.R
@@ -187,9 +187,10 @@ new_quosure <- function(expr, env = caller_env()) {
   .Call(rlang_new_quosure, expr, env)
 }
 #' @rdname quosure
+#' @inheritParams quosures
 #' @export
-enquo <- function(arg) {
-  .Call(rlang_enquo, substitute(arg), parent.frame())
+enquo <- function(arg, unquote_names = TRUE) {
+  .Call(rlang_enquo, substitute(arg), parent.frame(), unquote_names)
 }
 
 #' @export

--- a/R/quos.R
+++ b/R/quos.R
@@ -20,12 +20,14 @@
 #'    RHS. Unlike `quos()`, it allows named definitions.}
 #' }
 #' @param ... Expressions to capture unevaluated.
-#' @inheritParams dots_values
 #' @param .named Whether to ensure all dots are named. Unnamed
 #'   elements are processed with [expr_text()] to figure out a default
 #'   name. If an integer, it is passed to the `width` argument of
 #'   `expr_text()`, if `TRUE`, the default width is used. See
 #'   [exprs_auto_name()].
+#' @param .ignore_empty Whether to ignore empty arguments. Can be one
+#'   of `"trailing"`, `"none"`, `"all"`. If `"trailing"`, only the
+#'   last argument is ignored if it is empty.
 #' @param .unquote_names Whether to treat `:=` as `=`. Unlike `=`, the
 #'   `:=` syntax supports `!!` unquoting on the LHS.
 #' @export

--- a/R/quos.R
+++ b/R/quos.R
@@ -28,8 +28,9 @@
 #' @param .ignore_empty Whether to ignore empty arguments. Can be one
 #'   of `"trailing"`, `"none"`, `"all"`. If `"trailing"`, only the
 #'   last argument is ignored if it is empty.
-#' @param .unquote_names Whether to treat `:=` as `=`. Unlike `=`, the
-#'   `:=` syntax supports `!!` unquoting on the LHS.
+#' @param unquote_names,.unquote_names Whether to treat `:=` as
+#'   `=`. Unlike `=`, the `:=` syntax supports unquoting the name in
+#'   the LHS with `!!`.
 #' @export
 #' @name quosures
 #' @examples

--- a/R/vec-new.R
+++ b/R/vec-new.R
@@ -121,7 +121,7 @@ bytes <- function(...) {
 #' # Note that explicitly spliced lists are always spliced:
 #' ll(!!! list(1, 2))
 ll <- function(...) {
-  .Call(rlang_dots_list, environment(), FALSE, "trailing")
+  .Call(rlang_dots_list, environment(), FALSE, "trailing", TRUE)
 }
 
 

--- a/man/dots_list.Rd
+++ b/man/dots_list.Rd
@@ -20,8 +20,9 @@ arguments are embedded in the returned list.}
 of \code{"trailing"}, \code{"none"}, \code{"all"}. If \code{"trailing"}, only the
 last argument is ignored if it is empty.}
 
-\item{.unquote_names}{Whether to treat \code{:=} as \code{=}. Unlike \code{=}, the
-\code{:=} syntax supports unquoting with \code{!!}.}
+\item{.unquote_names}{Whether to treat \code{:=} as
+\code{=}. Unlike \code{=}, the \code{:=} syntax supports unquoting the name in
+the LHS with \code{!!}.}
 }
 \value{
 A list of arguments. This list is always named: unnamed

--- a/man/dots_list.Rd
+++ b/man/dots_list.Rd
@@ -5,9 +5,11 @@
 \alias{dots_splice}
 \title{Extract dots with splicing semantics}
 \usage{
-dots_list(..., .ignore_empty = c("trailing", "none", "all"))
+dots_list(..., .ignore_empty = c("trailing", "none", "all"),
+  .unquote_names = TRUE)
 
-dots_splice(..., .ignore_empty = c("trailing", "none", "all"))
+dots_splice(..., .ignore_empty = c("trailing", "none", "all"),
+  .unquote_names = TRUE)
 }
 \arguments{
 \item{...}{Arguments with explicit (\code{dots_list()}) or list
@@ -17,6 +19,9 @@ arguments are embedded in the returned list.}
 \item{.ignore_empty}{Whether to ignore empty arguments. Can be one
 of \code{"trailing"}, \code{"none"}, \code{"all"}. If \code{"trailing"}, only the
 last argument is ignored if it is empty.}
+
+\item{.unquote_names}{Whether to treat \code{:=} as \code{=}. Unlike \code{=}, the
+\code{:=} syntax supports unquoting with \code{!!}.}
 }
 \value{
 A list of arguments. This list is always named: unnamed

--- a/man/dots_values.Rd
+++ b/man/dots_values.Rd
@@ -14,8 +14,9 @@ dots_values(..., .ignore_empty = c("trailing", "none", "all"),
 of \code{"trailing"}, \code{"none"}, \code{"all"}. If \code{"trailing"}, only the
 last argument is ignored if it is empty.}
 
-\item{.unquote_names}{Whether to treat \code{:=} as \code{=}. Unlike \code{=}, the
-\code{:=} syntax supports unquoting with \code{!!}.}
+\item{.unquote_names}{Whether to treat \code{:=} as
+\code{=}. Unlike \code{=}, the \code{:=} syntax supports unquoting the name in
+the LHS with \code{!!}.}
 }
 \description{
 This is a tool for advanced users. It captures dots, processes

--- a/man/dots_values.Rd
+++ b/man/dots_values.Rd
@@ -4,7 +4,8 @@
 \alias{dots_values}
 \title{Evaluate dots with preliminary splicing}
 \usage{
-dots_values(..., .ignore_empty = c("trailing", "none", "all"))
+dots_values(..., .ignore_empty = c("trailing", "none", "all"),
+  .unquote_names = TRUE)
 }
 \arguments{
 \item{...}{Arguments to evaluate and process splicing operators.}
@@ -12,6 +13,9 @@ dots_values(..., .ignore_empty = c("trailing", "none", "all"))
 \item{.ignore_empty}{Whether to ignore empty arguments. Can be one
 of \code{"trailing"}, \code{"none"}, \code{"all"}. If \code{"trailing"}, only the
 last argument is ignored if it is empty.}
+
+\item{.unquote_names}{Whether to treat \code{:=} as \code{=}. Unlike \code{=}, the
+\code{:=} syntax supports unquoting with \code{!!}.}
 }
 \description{
 This is a tool for advanced users. It captures dots, processes

--- a/man/expr.Rd
+++ b/man/expr.Rd
@@ -11,7 +11,7 @@ ensym(arg)
 
 expr(expr)
 
-enexpr(arg)
+enexpr(arg, unquote_names = TRUE)
 
 exprs(..., .named = FALSE, .ignore_empty = c("trailing", "none", "all"),
   .unquote_names = TRUE)
@@ -21,6 +21,10 @@ exprs(..., .named = FALSE, .ignore_empty = c("trailing", "none", "all"),
 supplied to that argument will be captured unevaluated.}
 
 \item{expr}{An expression.}
+
+\item{unquote_names}{Whether to treat \code{:=} as
+\code{=}. Unlike \code{=}, the \code{:=} syntax supports unquoting the name in
+the LHS with \code{!!}.}
 
 \item{...}{Arguments to extract.}
 
@@ -34,8 +38,9 @@ name. If an integer, it is passed to the \code{width} argument of
 of \code{"trailing"}, \code{"none"}, \code{"all"}. If \code{"trailing"}, only the
 last argument is ignored if it is empty.}
 
-\item{.unquote_names}{Whether to treat \code{:=} as \code{=}. Unlike \code{=}, the
-\code{:=} syntax supports \code{!!} unquoting on the LHS.}
+\item{.unquote_names}{Whether to treat \code{:=} as
+\code{=}. Unlike \code{=}, the \code{:=} syntax supports unquoting the name in
+the LHS with \code{!!}.}
 }
 \value{
 The raw expression supplied as argument. \code{exprs()} returns

--- a/man/quosure.Rd
+++ b/man/quosure.Rd
@@ -11,7 +11,7 @@ quo(expr)
 
 new_quosure(expr, env = caller_env())
 
-enquo(arg)
+enquo(arg, unquote_names = TRUE)
 }
 \arguments{
 \item{expr}{An expression.}
@@ -21,6 +21,10 @@ quosure.}
 
 \item{arg}{A symbol referring to an argument. The expression
 supplied to that argument will be captured unevaluated.}
+
+\item{unquote_names}{Whether to treat \code{:=} as
+\code{=}. Unlike \code{=}, the \code{:=} syntax supports unquoting the name in
+the LHS with \code{!!}.}
 }
 \value{
 A formula whose right-hand side contains the quoted

--- a/man/quosures.Rd
+++ b/man/quosures.Rd
@@ -27,10 +27,11 @@ name. If an integer, it is passed to the \code{width} argument of
 of \code{"trailing"}, \code{"none"}, \code{"all"}. If \code{"trailing"}, only the
 last argument is ignored if it is empty.}
 
-\item{.unquote_names}{Whether to treat \code{:=} as \code{=}. Unlike \code{=}, the
-\code{:=} syntax supports \code{!!} unquoting on the LHS.}
-
 \item{x}{An object to test.}
+
+\item{unquote_names, .unquote_names}{Whether to treat \code{:=} as
+\code{=}. Unlike \code{=}, the \code{:=} syntax supports unquoting the name in
+the LHS with \code{!!}.}
 }
 \description{
 \code{quos()} quotes its arguments and returns them as a list of

--- a/src/arg.c
+++ b/src/arg.c
@@ -5,7 +5,7 @@
 
 SEXP rlang_ns_get(const char* name);
 
-SEXP capture(SEXP sym, SEXP frame, SEXP* arg_env) {
+SEXP capture(SEXP sym, SEXP frame, SEXP unquote_names, SEXP* arg_env) {
   static SEXP capture_call = NULL;
   if (!capture_call) {
     SEXP args = KEEP(r_new_node(r_null, r_null));
@@ -26,7 +26,7 @@ SEXP capture(SEXP sym, SEXP frame, SEXP* arg_env) {
 
   // Unquoting rearranges the expression
   expr = KEEP(r_duplicate(expr, false));
-  expr = call_interp(expr, env);
+  expr = call_interp(expr, env, r_as_bool(unquote_names));
 
   if (arg_env) {
     *arg_env = env;
@@ -36,16 +36,16 @@ SEXP capture(SEXP sym, SEXP frame, SEXP* arg_env) {
   return expr;
 }
 
-SEXP rlang_enexpr(SEXP sym, SEXP frame) {
-  return capture(sym, frame, NULL);
+SEXP rlang_enexpr(SEXP sym, SEXP frame, SEXP unquote_names) {
+  return capture(sym, frame, unquote_names, NULL);
 }
 
 
 SEXP forward_quosure(SEXP x, SEXP env);
 
-SEXP rlang_enquo(SEXP sym, SEXP frame) {
+SEXP rlang_enquo(SEXP sym, SEXP frame, SEXP unquote_names) {
   SEXP env;
-  SEXP expr = KEEP(capture(sym, frame, &env));
+  SEXP expr = KEEP(capture(sym, frame, unquote_names, &env));
   SEXP quo = forward_quosure(expr, env);
   FREE(1);
   return quo;

--- a/src/dots.c
+++ b/src/dots.c
@@ -69,8 +69,7 @@ static sexp* def_unquote_name(sexp* expr, sexp* env) {
   case OP_EXPAND_NONE:
     break;
   case OP_EXPAND_UQ:
-    lhs = KEEP(r_eval(info.operand, env));
-    ++n_kept;
+    lhs = KEEP_N(r_eval(info.operand, env), &n_kept);
     break;
   case OP_EXPAND_UQE:
     r_abort("The LHS of `:=` can't be unquoted with `UQE()`");

--- a/src/dots.c
+++ b/src/dots.c
@@ -59,44 +59,6 @@ struct dots_capture_info init_capture_info(enum dots_capture_type type,
 }
 
 
-static sexp* def_unquote_name(sexp* expr, sexp* env) {
-  int n_kept = 0;
-  sexp* lhs = r_node_cadr(expr);
-
-  struct expansion_info info = which_expansion_op(lhs, true);
-
-  switch (info.op) {
-  case OP_EXPAND_NONE:
-    break;
-  case OP_EXPAND_UQ:
-    lhs = KEEP_N(r_eval(info.operand, env), &n_kept);
-    break;
-  case OP_EXPAND_UQE:
-    r_abort("The LHS of `:=` can't be unquoted with `UQE()`");
-  case OP_EXPAND_UQS:
-    r_abort("The LHS of `:=` can't be spliced with `!!!`");
-  case OP_EXPAND_UQN:
-    r_abort("Internal error: Chained `:=` should have been detected earlier");
-  }
-
-  int err = 0;
-  lhs = r_new_symbol(lhs, &err);
-  if (err) {
-    r_abort("The LHS of `:=` must be a string or a symbol");
-  }
-
-  sexp* name = r_sym_str(lhs);
-
-  // Unserialise unicode points such as <U+xxx> that arise when
-  // UTF-8 names are converted to symbols and the native encoding
-  // does not support the characters (i.e. all the time on Windows)
-  name = r_str_unserialise_unicode(name);
-
-  FREE(n_kept);
-  return name;
-}
-
-
 static sexp* rlang_spliced_flag = NULL;
 
 static inline bool is_spliced_dots(sexp* x) {

--- a/src/dots.c
+++ b/src/dots.c
@@ -12,21 +12,22 @@ enum dots_capture_type {
   DOTS_VALUE
 };
 
-#define N_EXPANSION_OPS 4
-
 enum dots_expansion_op {
   OP_EXPR_NONE,
   OP_EXPR_UQ,
   OP_EXPR_UQE,
   OP_EXPR_UQS,
+  OP_EXPR_UQN,
   OP_QUO_NONE,
   OP_QUO_UQ,
   OP_QUO_UQE,
   OP_QUO_UQS,
+  OP_QUO_UQN,
   OP_VALUE_NONE,
   OP_VALUE_UQ,
   OP_VALUE_UQE,
-  OP_VALUE_UQS
+  OP_VALUE_UQS,
+  OP_VALUE_UQN
 };
 
 struct dots_capture_info {
@@ -62,7 +63,7 @@ static sexp* def_unquote_name(sexp* expr, sexp* env) {
   int n_kept = 0;
   sexp* lhs = r_node_cadr(expr);
 
-  struct expansion_info info = which_expansion_op(lhs);
+  struct expansion_info info = which_expansion_op(lhs, true);
 
   switch (info.op) {
   case OP_EXPAND_NONE:
@@ -75,6 +76,8 @@ static sexp* def_unquote_name(sexp* expr, sexp* env) {
     r_abort("The LHS of `:=` can't be unquoted with `UQE()`");
   case OP_EXPAND_UQS:
     r_abort("The LHS of `:=` can't be spliced with `!!!`");
+  case OP_EXPAND_UQN:
+    r_abort("Internal error: Chained `:=` should have been detected earlier");
   }
 
   int err = 0;
@@ -186,6 +189,7 @@ static sexp* dots_unquote(sexp* dots, struct dots_capture_info* capture_info) {
   sexp* dots_names = r_names(dots);
   capture_info->count = 0;
   r_size_t n = r_length(dots);
+  bool unquote_names = capture_info->unquote_names;
 
   for (r_size_t i = 0; i < n; ++i) {
     sexp* elt = r_list_get(dots, i);
@@ -195,7 +199,7 @@ static sexp* dots_unquote(sexp* dots, struct dots_capture_info* capture_info) {
     // Unquoting rearranges expressions
     expr = KEEP(r_duplicate(expr, false));
 
-    if (capture_info->unquote_names && r_is_call(expr, ":=")) {
+    if (unquote_names && r_is_call(expr, ":=")) {
       sexp* name = def_unquote_name(expr, env);
 
       if (dots_names == r_null) {
@@ -212,7 +216,7 @@ static sexp* dots_unquote(sexp* dots, struct dots_capture_info* capture_info) {
       expr = r_node_cadr(r_node_cdr(expr));
     }
 
-    struct expansion_info info = which_expansion_op(expr);
+    struct expansion_info info = which_expansion_op(expr, unquote_names);
     enum dots_expansion_op dots_op = info.op + (N_EXPANSION_OPS * capture_info->type);
 
     // Ignore empty arguments
@@ -229,7 +233,7 @@ static sexp* dots_unquote(sexp* dots, struct dots_capture_info* capture_info) {
     case OP_EXPR_NONE:
     case OP_EXPR_UQ:
     case OP_EXPR_UQE:
-      expr = call_interp_impl(expr, env, info);
+      expr = call_interp_impl(expr, env, info, capture_info->unquote_names);
       capture_info->count += 1;
       break;
     case OP_EXPR_UQS:
@@ -239,7 +243,7 @@ static sexp* dots_unquote(sexp* dots, struct dots_capture_info* capture_info) {
     case OP_QUO_NONE:
     case OP_QUO_UQ:
     case OP_QUO_UQE: {
-      expr = KEEP(call_interp_impl(expr, env, info));
+      expr = KEEP(call_interp_impl(expr, env, info, capture_info->unquote_names));
       expr = forward_quosure(expr, env);
       FREE(1);
       capture_info->count += 1;
@@ -274,7 +278,12 @@ static sexp* dots_unquote(sexp* dots, struct dots_capture_info* capture_info) {
       }
       FREE(1);
       break;
-    }}
+    }
+    case OP_EXPR_UQN:
+    case OP_QUO_UQN:
+    case OP_VALUE_UQN:
+      r_abort("`:=` can't be chained");
+    }
 
     r_list_poke(dots, i, expr);
     FREE(1);
@@ -473,10 +482,9 @@ static bool is_spliced_bare_dots_value(SEXP x) {
   return true;
 }
 
-static sexp* dots_values_impl(sexp* frame_env, sexp* named, sexp* ignore_empty,
+static sexp* dots_values_impl(sexp* frame_env, sexp* named,
+                              sexp* ignore_empty, sexp* unquote_names,
                               bool (*is_spliced)(SEXP)) {
-  sexp* unquote_names = KEEP(r_scalar_lgl(1));
-
   struct dots_capture_info capture_info;
   capture_info = init_capture_info(DOTS_VALUE, named, ignore_empty, unquote_names);
   sexp* dots = dots_init(&capture_info, frame_env);
@@ -490,15 +498,18 @@ static sexp* dots_values_impl(sexp* frame_env, sexp* named, sexp* ignore_empty,
     }
   }
 
-  FREE(2);
+  FREE(1);
   return dots;
 }
-sexp* rlang_dots_values(sexp* frame_env, sexp* named, sexp* ignore_empty) {
-  return dots_values_impl(frame_env, named, ignore_empty, NULL);
+sexp* rlang_dots_values(sexp* frame_env, sexp* named,
+                        sexp* ignore_empty, sexp* unquote_names) {
+  return dots_values_impl(frame_env, named, ignore_empty, unquote_names, NULL);
 }
-sexp* rlang_dots_list(sexp* frame_env, sexp* named, sexp* ignore_empty) {
-  return dots_values_impl(frame_env, named, ignore_empty, is_spliced_dots_value);
+sexp* rlang_dots_list(sexp* frame_env, sexp* named,
+                      sexp* ignore_empty, sexp* unquote_names) {
+  return dots_values_impl(frame_env, named, ignore_empty, unquote_names, is_spliced_dots_value);
 }
-sexp* rlang_dots_flat_list(sexp* frame_env, sexp* named, sexp* ignore_empty) {
-  return dots_values_impl(frame_env, named, ignore_empty, is_spliced_bare_dots_value);
+sexp* rlang_dots_flat_list(sexp* frame_env, sexp* named,
+                           sexp* ignore_empty, sexp* unquote_names) {
+  return dots_values_impl(frame_env, named, ignore_empty, unquote_names, is_spliced_bare_dots_value);
 }

--- a/src/expr-interp.c
+++ b/src/expr-interp.c
@@ -301,6 +301,11 @@ static sexp* node_list_interp(sexp* x, sexp* env, bool unquote_names) {
       sexp* name = def_unquote_name(next_head, env);
       r_node_poke_tag(next, r_str_sym(name));
       r_node_poke_car(next, r_node_cadr(r_node_cdr(next_head)));
+
+      if (r_is_call(r_node_car(next), ":=")) {
+        r_abort("`:=` can't be chained");
+      }
+
       break;
     }
     default:

--- a/src/expr-interp.h
+++ b/src/expr-interp.h
@@ -35,11 +35,14 @@ static inline bool is_splice_call(sexp* node) {
 }
 
 
+#define N_EXPANSION_OPS 5
+
 enum expansion_op {
   OP_EXPAND_NONE,
   OP_EXPAND_UQ,
   OP_EXPAND_UQE,
   OP_EXPAND_UQS,
+  OP_EXPAND_UQN
 };
 
 struct expansion_info {
@@ -61,13 +64,14 @@ static inline struct expansion_info init_expansion_info() {
 }
 
 struct expansion_info which_bang_op(sexp* x);
-struct expansion_info which_expansion_op(sexp* x);
+struct expansion_info which_expansion_op(sexp* x, bool unquote_names);
 
 sexp* big_bang_coerce(sexp* expr);
 
-sexp* rlang_interp(sexp* x, sexp* env);
-sexp* call_interp(sexp* x, sexp* env);
-sexp* call_interp_impl(sexp* x, sexp* env, struct expansion_info info);
+sexp* rlang_interp(sexp* x, sexp* env, sexp* unquote_names);
+sexp* call_interp(sexp* x, sexp* env, bool unquote_names);
+sexp* call_interp_impl(sexp* x, sexp* env, struct expansion_info info,
+                       bool unquote_names);
 
 
 static inline sexp* forward_quosure(sexp* x, sexp* env) {

--- a/src/expr-interp.h
+++ b/src/expr-interp.h
@@ -66,6 +66,7 @@ static inline struct expansion_info init_expansion_info() {
 struct expansion_info which_bang_op(sexp* x);
 struct expansion_info which_expansion_op(sexp* x, bool unquote_names);
 
+sexp* def_unquote_name(sexp* expr, sexp* env);
 sexp* big_bang_coerce(sexp* expr);
 
 sexp* rlang_interp(sexp* x, sexp* env, sexp* unquote_names);

--- a/src/init.c
+++ b/src/init.c
@@ -65,8 +65,8 @@ extern SEXP rlang_dots_flat_list(SEXP, SEXP, SEXP, SEXP);
 extern SEXP r_new_formula(SEXP, SEXP, SEXP);
 extern SEXP r_new_quosure(SEXP, SEXP);
 extern SEXP rlang_poke_attributes(SEXP, SEXP);
-extern SEXP rlang_enexpr(SEXP, SEXP);
-extern SEXP rlang_enquo(SEXP, SEXP);
+extern SEXP rlang_enexpr(SEXP, SEXP, SEXP);
+extern SEXP rlang_enquo(SEXP, SEXP, SEXP);
 extern SEXP r_get_expression(SEXP, SEXP);
 extern SEXP rlang_vec_coerce(SEXP, SEXP);
 
@@ -141,8 +141,8 @@ static const R_CallMethodDef call_entries[] = {
   {"rlang_new_formula",         (DL_FUNC) &r_new_formula, 3},
   {"rlang_new_quosure",         (DL_FUNC) &r_new_quosure, 2},
   {"rlang_poke_attributes",     (DL_FUNC) &rlang_poke_attributes, 2},
-  {"rlang_enexpr",              (DL_FUNC) &rlang_enexpr, 2},
-  {"rlang_enquo",               (DL_FUNC) &rlang_enquo, 2},
+  {"rlang_enexpr",              (DL_FUNC) &rlang_enexpr, 3},
+  {"rlang_enquo",               (DL_FUNC) &rlang_enquo, 3},
   {"rlang_get_expression",      (DL_FUNC) &r_get_expression, 2},
   {"rlang_vec_coerce",          (DL_FUNC) &rlang_vec_coerce, 2},
   {NULL, NULL, 0}

--- a/src/init.c
+++ b/src/init.c
@@ -59,9 +59,9 @@ extern SEXP rlang_cnd_warn(SEXP, SEXP);
 extern SEXP rlang_r_string(SEXP);
 extern SEXP rlang_exprs_interp(SEXP, SEXP, SEXP, SEXP);
 extern SEXP rlang_quos_interp(SEXP, SEXP, SEXP, SEXP);
-extern SEXP rlang_dots_values(SEXP, SEXP, SEXP);
-extern SEXP rlang_dots_list(SEXP, SEXP, SEXP);
-extern SEXP rlang_dots_flat_list(SEXP, SEXP, SEXP);
+extern SEXP rlang_dots_values(SEXP, SEXP, SEXP, SEXP);
+extern SEXP rlang_dots_list(SEXP, SEXP, SEXP, SEXP);
+extern SEXP rlang_dots_flat_list(SEXP, SEXP, SEXP, SEXP);
 extern SEXP r_new_formula(SEXP, SEXP, SEXP);
 extern SEXP r_new_quosure(SEXP, SEXP);
 extern SEXP rlang_poke_attributes(SEXP, SEXP);
@@ -135,9 +135,9 @@ static const R_CallMethodDef call_entries[] = {
   {"rlang_r_string",            (DL_FUNC) &rlang_r_string, 1},
   {"rlang_exprs_interp",        (DL_FUNC) &rlang_exprs_interp, 4},
   {"rlang_quos_interp",         (DL_FUNC) &rlang_quos_interp, 4},
-  {"rlang_dots_values",         (DL_FUNC) &rlang_dots_values, 3},
-  {"rlang_dots_list",           (DL_FUNC) &rlang_dots_list, 3},
-  {"rlang_dots_flat_list",      (DL_FUNC) &rlang_dots_flat_list, 3},
+  {"rlang_dots_values",         (DL_FUNC) &rlang_dots_values, 4},
+  {"rlang_dots_list",           (DL_FUNC) &rlang_dots_list, 4},
+  {"rlang_dots_flat_list",      (DL_FUNC) &rlang_dots_flat_list, 4},
   {"rlang_new_formula",         (DL_FUNC) &r_new_formula, 3},
   {"rlang_new_quosure",         (DL_FUNC) &r_new_quosure, 2},
   {"rlang_poke_attributes",     (DL_FUNC) &rlang_poke_attributes, 2},

--- a/src/rlang/rlang.h
+++ b/src/rlang/rlang.h
@@ -49,6 +49,11 @@ enum r_type {
 #define KEEP PROTECT
 #define FREE UNPROTECT
 
+static inline sexp* KEEP_N(sexp* x, int* n) {
+  ++(*n);
+  return KEEP(x);
+}
+
 #include "attrs.h"
 #include "cnd.h"
 #include "env.h"

--- a/src/rlang/vec-chr.h
+++ b/src/rlang/vec-chr.h
@@ -52,6 +52,12 @@ static inline const char* r_c_string(SEXP scalar_chr) {
   return CHAR(r_chr_get(scalar_chr, 0));
 }
 
+static inline const char* r_str_c_str(SEXP str) {
+  return CHAR(str);
+}
+static inline sexp* r_str_sym(SEXP str) {
+  return r_sym(CHAR(str));
+}
 
 SEXP chr_prepend(SEXP chr, SEXP r_string);
 SEXP chr_append(SEXP chr, SEXP r_string);

--- a/tests/testthat/helper-capture.R
+++ b/tests/testthat/helper-capture.R
@@ -8,3 +8,6 @@ named_list <- function(...) {
 quos_list <- function(...) {
   set_attrs(named_list(...), class = "quosures")
 }
+
+bare_expr <- function(expr) enexpr(expr, unquote_names = FALSE)
+bare_quo <- function(expr) enquo(expr, unquote_names = FALSE)

--- a/tests/testthat/test-tidy-unquote.R
+++ b/tests/testthat/test-tidy-unquote.R
@@ -272,6 +272,9 @@ test_that("`:=` chaining is detected at dots capture", {
   expect_error(quos(a := b := c), "chained")
   expect_error(dots_list(a := b := c), "chained")
   expect_error(dots_splice(a := b := c), "chained")
+
+  expect_error(expr(foo(a := b := c)), "chained")
+  expect_identical(bare_expr(foo(a := b := c)), quote(foo(a := b := c)))
 })
 
 test_that("can unquote names deeply", {
@@ -280,8 +283,14 @@ test_that("can unquote names deeply", {
 
   expect_identical(expr(foo(a := bar(b := baz))), quote(foo(a = bar(b = baz))))
 
-  bare_expr <- function(expr) enexpr(expr, unquote_names = FALSE)
-  bare_quo <- function(expr) enquo(expr, unquote_names = FALSE)
   expect_identical(bare_expr(foo(a := bar())), quote(foo(a := bar())))
   expect_identical(bare_quo(foo(a := bar())), new_quosure(quote(foo(a := bar()))))
+})
+
+test_that("can't use `:=` at top level", {
+  expect_error(expr(a := b), "top level")
+  expect_error(quo(a := b), "top level")
+
+  expect_identical(bare_expr(a := b), quote(a := b))
+  expect_identical(bare_quo(a := b), new_quosure(quote(a := b)))
 })

--- a/tests/testthat/test-tidy-unquote.R
+++ b/tests/testthat/test-tidy-unquote.R
@@ -273,3 +273,15 @@ test_that("`:=` chaining is detected at dots capture", {
   expect_error(dots_list(a := b := c), "chained")
   expect_error(dots_splice(a := b := c), "chained")
 })
+
+test_that("can unquote names deeply", {
+  expect_identical(expr(foo(a := bar())), quote(foo(a = bar())))
+  expect_identical(quo(foo(a := bar())), new_quosure(quote(foo(a = bar()))))
+
+  expect_identical(expr(foo(a := bar(b := baz))), quote(foo(a = bar(b = baz))))
+
+  bare_expr <- function(expr) enexpr(expr, unquote_names = FALSE)
+  bare_quo <- function(expr) enquo(expr, unquote_names = FALSE)
+  expect_identical(bare_expr(foo(a := bar())), quote(foo(a := bar())))
+  expect_identical(bare_quo(foo(a := bar())), new_quosure(quote(foo(a := bar()))))
+})

--- a/tests/testthat/test-tidy-unquote.R
+++ b/tests/testthat/test-tidy-unquote.R
@@ -252,3 +252,24 @@ test_that("can unquote symbols", {
   expect_error(dots_values(!! quote(.)), "`!!` in a non-quoting function")
   expect_error(dots_values(rlang::UQ(quote(.))), "`!!` in a non-quoting function")
 })
+
+
+# := -----------------------------------------------------------------
+
+test_that("`:=` unquotes its LHS as name unless `.unquote_names` is FALSE", {
+  expect_identical(exprs(a := b), list(a = quote(b)))
+  expect_identical(exprs(a := b, .unquote_names = FALSE), named_list(quote(a := b)))
+  expect_identical(quos(a := b), quos_list(a = quo(b)))
+  expect_identical(quos(a := b, .unquote_names = FALSE), quos_list(new_quosure(quote(a := b))))
+  expect_identical(dots_list(a := NULL), list(a = NULL))
+  expect_identical(dots_list(a := NULL, .unquote_names = FALSE), named_list(a := NULL))
+  expect_identical(dots_splice(a := NULL), list(a = NULL))
+  expect_identical(dots_splice(a := NULL, .unquote_names = FALSE), named_list(a := NULL))
+})
+
+test_that("`:=` chaining is detected at dots capture", {
+  expect_error(exprs(a := b := c), "chained")
+  expect_error(quos(a := b := c), "chained")
+  expect_error(dots_list(a := b := c), "chained")
+  expect_error(dots_splice(a := b := c), "chained")
+})


### PR DESCRIPTION
Includes #297, closes #279.

To treat `expr(list(a := foo))` as synonym of `expr(list(a = foo))` and allow name-unquoting everywhere.

I'm not too fond of the `unquote_names` argument name, but I can't think of anything better.