### PR TITLE
separate expressions by semicolons, not colons

### DIFF
--- a/R/parse.R
+++ b/R/parse.R
@@ -5,7 +5,7 @@
 #' written by a programmer.
 #'
 #' `parse_expr()` returns one expression. If the text contains more
-#' than one expression (separated by colons or new lines), an error is
+#' than one expression (separated by semicolons or new lines), an error is
 #' issued. On the other hand `parse_exprs()` can handle multiple
 #' expressions. It always returns a list of expressions (compare to
 #' [base::parse()] which returns an base::expression vector). All


### PR DESCRIPTION
If a colon is used  to separate expressions as the documentation currently states parse_exprs and parse_quosures will return a single expression/quosure, not multiple