### PR TITLE
parse_expr returns language object not formula

### DIFF
--- a/R/parse.R
+++ b/R/parse.R
@@ -21,8 +21,8 @@
 #' @param env The environment for the formulas. Defaults to the
 #'   context in which the parse_expr function was called. Can be any
 #'   object with a `as_env()` method.
-#' @return `parse_expr()` returns a formula, `parse_exprs()` returns a
-#'   list of formulas.
+#' @return `parse_expr()` returns a language object, `parse_exprs()` returns a
+#'   list of language objects
 #' @seealso [base::parse()]
 #' @export
 #' @examples


### PR DESCRIPTION
There is no formula in the object returned by parse_expr or parse_exprs. The typeof(parse_expr("asdf")) is language and its class is call.

I don't know how to add the @return for parse_quosure but parse_quosure returns a language object too but its class is quosure which derives from formula.