### PR TITLE
Add documentation of `.env` vs. unquoting

### DIFF
--- a/R/eval-tidy.R
+++ b/R/eval-tidy.R
@@ -85,16 +85,20 @@
 #' eval_tidy(quo(.data$cyl), mtcars)
 #' eval_tidy(quo(.env$cyl), mtcars)
 #'
-#' # Note that instead of using `.env` it is often equivalent and often
+#' # Note that instead of using `.env` it is often equivalent and may be
 #' # preferred to unquote a value. There are two differences. First unquoting
-#' # happens earlier, when the quosure is created. Second, `.env` will not
-#' # look in a parent environment, while unquoting will. (Note also that
-#' # magrittr pipes, such as `%>%`, create a child environment where `.env`
-#' # will not work properly)
+#' # happens earlier, when the quosure is created. Secondly, subsetting `.env`
+#' # with the `$` operator may be brittle because `$` does not look through
+#' # the parents of the environment. Using `.env$name` in a magrittr pipeline
+#' # is an instance where this poses problem, because the magrittr pipe
+#' # currently (as of v1.5.0) evaluates its operands in a *child* of the
+#' # current environment (this child environment is where it defines the
+#' # pronoun `.`).
+#'
 #' eval_tidy(quo(!! cyl), mtcars)  # 10
 #' \dontrun{
 #'   mtcars %>% eval_tidy(quo(!! cyl), .)  # 10
-#'   mtcars %>% eval_tidy(quo(!! cyl), .)  # NULL
+#'   mtcars %>% eval_tidy(quo(.env$cyl), .)  # NULL
 #' }
 #' @name eval_tidy
 eval_tidy <- function(expr, data = NULL, env = caller_env()) {

--- a/R/eval-tidy.R
+++ b/R/eval-tidy.R
@@ -85,10 +85,17 @@
 #' eval_tidy(quo(.data$cyl), mtcars)
 #' eval_tidy(quo(.env$cyl), mtcars)
 #'
-#' # Note that instead of using `.env` it is often equivalent to
-#' # unquote a value. The only difference is the timing of evaluation
-#' # since unquoting happens earlier (when the quosure is created):
-#' eval_tidy(quo(!! cyl), mtcars)
+#' # Note that instead of using `.env` it is often equivalent and often
+#' # preferred to unquote a value. There are two differences. First unquoting
+#' # happens earlier, when the quosure is created. Second, `.env` will not
+#' # look in a parent environment, while unquoting will. (Note also that
+#' # magrittr pipes, such as `%>%`, create a child environment where `.env`
+#' # will not work properly)
+#' eval_tidy(quo(!! cyl), mtcars)  # 10
+#' \dontrun{
+#'   mtcars %>% eval_tidy(quo(!! cyl), .)  # 10
+#'   mtcars %>% eval_tidy(quo(!! cyl), .)  # NULL
+#' }
 #' @name eval_tidy
 eval_tidy <- function(expr, data = NULL, env = caller_env()) {
   if (!inherits(expr, "quosure")) {

--- a/man/eval_tidy.Rd
+++ b/man/eval_tidy.Rd
@@ -89,10 +89,17 @@ eval_tidy(quo(cyl), mtcars)
 eval_tidy(quo(.data$cyl), mtcars)
 eval_tidy(quo(.env$cyl), mtcars)
 
-# Note that instead of using `.env` it is often equivalent to
-# unquote a value. The only difference is the timing of evaluation
-# since unquoting happens earlier (when the quosure is created):
-eval_tidy(quo(!! cyl), mtcars)
+# Note that instead of using `.env` it is often equivalent and often
+# preferred to unquote a value. There are two differences. First unquoting
+# happens earlier, when the quosure is created. Second, `.env` will not
+# look in a parent environment, while unquoting will. (Note also that
+# magrittr pipes, such as `\%>\%`, create a child environment where `.env`
+# will not work properly)
+eval_tidy(quo(!! cyl), mtcars)  # 10
+\dontrun{
+  mtcars \%>\% eval_tidy(quo(!! cyl), .)  # 10
+  mtcars \%>\% eval_tidy(quo(!! cyl), .)  # NULL
+}
 }
 \seealso{
 \code{\link[=quo]{quo()}}, \link{quasiquotation}

--- a/man/eval_tidy.Rd
+++ b/man/eval_tidy.Rd
@@ -89,16 +89,20 @@ eval_tidy(quo(cyl), mtcars)
 eval_tidy(quo(.data$cyl), mtcars)
 eval_tidy(quo(.env$cyl), mtcars)
 
-# Note that instead of using `.env` it is often equivalent and often
+# Note that instead of using `.env` it is often equivalent and may be
 # preferred to unquote a value. There are two differences. First unquoting
-# happens earlier, when the quosure is created. Second, `.env` will not
-# look in a parent environment, while unquoting will. (Note also that
-# magrittr pipes, such as `\%>\%`, create a child environment where `.env`
-# will not work properly)
+# happens earlier, when the quosure is created. Secondly, subsetting `.env`
+# with the `$` operator may be brittle because `$` does not look through
+# the parents of the environment. Using `.env$name` in a magrittr pipeline
+# is an instance where this poses problem, because the magrittr pipe
+# currently (as of v1.5.0) evaluates its operands in a *child* of the
+# current environment (this child environment is where it defines the
+# pronoun `.`).
+
 eval_tidy(quo(!! cyl), mtcars)  # 10
 \dontrun{
   mtcars \%>\% eval_tidy(quo(!! cyl), .)  # 10
-  mtcars \%>\% eval_tidy(quo(!! cyl), .)  # NULL
+  mtcars \%>\% eval_tidy(quo(.env$cyl), .)  # NULL
 }
 }
 \seealso{


### PR DESCRIPTION
I added a little documentation to capture @lionel-'s comments from https://github.com/tidyverse/dplyr/issues/3286. Feel free to merge if this is helpful, not worries if it's not.


I added a few examples that use magrittr pipes (`%>%`), but `\dontrun{}`-ed run them to avoid making magrittr a dependency.