### PR TITLE
fix typo in lang_head() and lang_tail()

### DIFF
--- a/R/lifecycle-retired.R
+++ b/R/lifecycle-retired.R
@@ -133,14 +133,14 @@ lang_args_names <- function(lang) {
 #' @param lang A call.
 #' @export
 lang_head <- function(lang) {
-  call <- get_expr(call)
+  call <- get_expr(lang)
   stopifnot(is_call(call))
   node_car(call)
 }
 #' @rdname lang_head
 #' @export
 lang_tail <- function(lang) {
-  call <- get_expr(call)
+  call <- get_expr(lang)
   stopifnot(is_call(call))
   node_cdr(call)
 }

--- a/tests/testthat/test-retired.R
+++ b/tests/testthat/test-retired.R
@@ -1,0 +1,15 @@
+context("retired")
+
+test_that("lang_tail() works properly", {
+  expect_identical(
+    pairlist(sym("a")),
+    lang_tail(expr(foo(a)))
+  )
+})
+
+test_that("lang_head() works properly", {
+  expect_identical(
+    lang_head(expr(foo(a))),
+    expr(foo)
+  )
+})


### PR DESCRIPTION
Will be refactoring to `node_cdr()` on our end but figured this is worth fixing in case it breaks stuff in the wild.

cc @lionel- this is the issue I mentioned

Closes https://github.com/rstudio/sparklyr/issues/1221